### PR TITLE
Bump kube state metrics version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project's packages adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [v0.6.0]
+
+### Changed
+
+- Upgraded to kube-state-metrics [new release 1.8.0](https://github.com/kubernetes/kube-state-metrics/releases/tag/v1.8.0)
+
 ## [v0.5.0]
 
 ### Changed

--- a/helm/kube-state-metrics-app/Chart.yaml
+++ b/helm/kube-state-metrics-app/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: v1.7.2
+appVersion: v1.8.0
 description: A Helm chart for the Kubernetes kube-state-metrics service
 name: kube-state-metrics-app
-version: 0.5.0-[[ .SHA ]]
+version: 0.6.0-[[ .SHA ]]

--- a/helm/kube-state-metrics-app/Chart.yaml
+++ b/helm/kube-state-metrics-app/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: v1.8.0
 description: A Helm chart for the Kubernetes kube-state-metrics service
 name: kube-state-metrics-app
-version: 0.6.0-[[ .SHA ]]
+version: [[ .Version ]]

--- a/helm/kube-state-metrics-app/values.yaml
+++ b/helm/kube-state-metrics-app/values.yaml
@@ -12,7 +12,7 @@ replicas: 1
 image:
   registry: quay.io
   repository: giantswarm/kube-state-metrics
-  tag: v1.7.2
+  tag: v1.8.0
 
 imageResizer:
   registry: quay.io


### PR DESCRIPTION
Following https://github.com/giantswarm/retagger/pull/273
Bump kube state metrics version to match newer upstream version for 1.15.4 release