### PR TITLE
Fixes for image registry templating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 ### Changed
 
 - Upgraded to kube-state-metrics [new release 1.8.0](https://github.com/kubernetes/kube-state-metrics/releases/tag/v1.8.0)
+- Fix templating for image registry.
 
 ## [v0.5.0]
 

--- a/helm/kube-state-metrics-app/templates/deployment.yaml
+++ b/helm/kube-state-metrics-app/templates/deployment.yaml
@@ -38,7 +38,7 @@ spec:
           initialDelaySeconds: 5
           timeoutSeconds: 5
       - name: addon-resizer
-        image: "{{ .Values.imageResizer.registry }}/{{ .Values.imageResizer.repository }}:{{ .Values.imageResizer.tag }}"
+        image: "{{ .Values.image.registry }}/{{ .Values.imageResizer.repository }}:{{ .Values.imageResizer.tag }}"
         resources:
           limits:
             cpu: 150m

--- a/helm/kube-state-metrics-app/templates/deployment.yaml
+++ b/helm/kube-state-metrics-app/templates/deployment.yaml
@@ -22,7 +22,7 @@ spec:
       priorityClassName: giantswarm-critical
       containers:
       - name: {{ .Values.name }}
-        image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        image: "{{ .Values.image.registry }}/{{ .Values.image.name }}:{{ .Values.image.tag }}"
         args:
         - '--port={{ .Values.port }}'
         livenessProbe:
@@ -38,7 +38,7 @@ spec:
           initialDelaySeconds: 5
           timeoutSeconds: 5
       - name: addon-resizer
-        image: "{{ .Values.image.registry }}/{{ .Values.imageResizer.repository }}:{{ .Values.imageResizer.tag }}"
+        image: "{{ .Values.image.registry }}/{{ .Values.imageResizer.name }}:{{ .Values.imageResizer.tag }}"
         resources:
           limits:
             cpu: 150m

--- a/helm/kube-state-metrics-app/templates/test/test-runner.yaml
+++ b/helm/kube-state-metrics-app/templates/test/test-runner.yaml
@@ -22,7 +22,7 @@ spec:
       name: tools
   containers:
   - name: {{ .Values.name }}-test
-    image: "{{ .Values.image.registry }}/{{ .Values.test.image.repository }}:{{ .Values.test.image.tag }}"
+    image: "{{ .Values.image.registry }}/{{ .Values.test.image.name }}:{{ .Values.test.image.tag }}"
     imagePullPolicy: IfNotPresent
     command: ["/tools/bats/bats", "-t", "/tests/run.sh"]
     volumeMounts:

--- a/helm/kube-state-metrics-app/templates/test/test-runner.yaml
+++ b/helm/kube-state-metrics-app/templates/test/test-runner.yaml
@@ -22,7 +22,7 @@ spec:
       name: tools
   containers:
   - name: {{ .Values.name }}-test
-    image: "{{ .Values.test.image.registry }}/{{ .Values.test.image.repository }}:{{ .Values.test.image.tag }}"
+    image: "{{ .Values.image.registry }}/{{ .Values.test.image.repository }}:{{ .Values.test.image.tag }}"
     imagePullPolicy: IfNotPresent
     command: ["/tools/bats/bats", "-t", "/tests/run.sh"]
     volumeMounts:

--- a/helm/kube-state-metrics-app/values.yaml
+++ b/helm/kube-state-metrics-app/values.yaml
@@ -15,12 +15,10 @@ image:
   tag: v1.8.0
 
 imageResizer:
-  registry: quay.io
   repository: giantswarm/addon-resizer
   tag: 1.8.4
 
 test:
   image:
-    registry: quay.io
     repository: giantswarm/alpine-testing
     tag: 0.1.0

--- a/helm/kube-state-metrics-app/values.yaml
+++ b/helm/kube-state-metrics-app/values.yaml
@@ -11,14 +11,14 @@ replicas: 1
 
 image:
   registry: quay.io
-  repository: giantswarm/kube-state-metrics
+  name: giantswarm/kube-state-metrics
   tag: v1.8.0
 
 imageResizer:
-  repository: giantswarm/addon-resizer
+  name: giantswarm/addon-resizer
   tag: 1.8.4
 
 test:
   image:
-    repository: giantswarm/alpine-testing
+    name: giantswarm/alpine-testing
     tag: 0.1.0


### PR DESCRIPTION
Fixes problems with templating for the image registry. We should only define `image.registry` once as this is the value we override for AWS China.