### PR TITLE
Upgrade kube-state-metrics to v1.9.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ### Changed
 
-- Upgraded to kube-state-metrics [new release 1.9.2](https://github.com/kubernetes/kube-state-metrics/releases/tag/v1.9.2)
+- Upgrade to kube-state-metrics [1.9.2](https://github.com/kubernetes/kube-state-metrics/releases/tag/v1.9.2)
 - Upgrade to k8s 1.16 compatible addon-resizer release 1.8.7
 
 ## [v1.0.0]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project's packages adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [v1.0.1]
+
+### Changed
+
+- Upgraded to kube-state-metrics [new release 1.9.2](https://github.com/kubernetes/kube-state-metrics/releases/tag/v1.9.2)
+- Upgrade to k8s 1.16 compatible addon-resizer release 1.8.7
+
 ## [v1.0.0]
 
 ### Changed
@@ -61,7 +68,12 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 - Upgraded to kube state metric [new release 1.6.0](https://github.com/kubernetes/kube-state-metrics/releases/tag/v1.6.0)
 - Tunned the addon resizer for bigger clusters.
 
-[0.4.0]: https://github.com/giantswarm/kubernetes-kube-state-metrics/pull/49
-[0.3.4]: https://github.com/giantswarm/kubernetes-kube-state-metrics/pull/47
-[0.3.1]: https://github.com/giantswarm/kubernetes-kube-state-metrics/pull/43
-[0.3.0]: https://github.com/giantswarm/kubernetes-kube-state-metrics/pull/40
+[v1.0.1]: https://github.com/giantswarm/kube-state-metrics-app/releases/tag/v1.0.1
+[v1.0.0]: https://github.com/giantswarm/kube-state-metrics-app/releases/tag/v1.0.0
+[v0.7.0]: https://github.com/giantswarm/kube-state-metrics-app/releases/tag/v0.7.0
+[v0.6.0]: https://github.com/giantswarm/kube-state-metrics-app/releases/tag/v0.6.0
+[v0.5.0]: https://github.com/giantswarm/kube-state-metrics-app/releases/tag/v0.5.0
+[v0.4.0]: https://github.com/giantswarm/kubernetes-kube-state-metrics/pull/49
+[v0.3.4]: https://github.com/giantswarm/kubernetes-kube-state-metrics/pull/47
+[v0.3.1]: https://github.com/giantswarm/kubernetes-kube-state-metrics/pull/43
+[v0.3.0]: https://github.com/giantswarm/kubernetes-kube-state-metrics/pull/40

--- a/helm/kube-state-metrics-app/Chart.yaml
+++ b/helm/kube-state-metrics-app/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: v1.8.0
+appVersion: v1.9.2
 description: A Helm chart for the Kubernetes kube-state-metrics service
 name: kube-state-metrics-app
 version: [[ .Version ]]

--- a/helm/kube-state-metrics-app/values.yaml
+++ b/helm/kube-state-metrics-app/values.yaml
@@ -12,7 +12,7 @@ replicas: 1
 image:
   registry: quay.io
   name: giantswarm/kube-state-metrics
-  tag: v1.9.0
+  tag: v1.9.2
 
 imageResizer:
   name: giantswarm/addon-resizer

--- a/helm/kube-state-metrics-app/values.yaml
+++ b/helm/kube-state-metrics-app/values.yaml
@@ -16,7 +16,7 @@ image:
 
 imageResizer:
   name: giantswarm/addon-resizer
-  tag: 1.8.4
+  tag: 1.8.7
 
 test:
   image:

--- a/helm/kube-state-metrics-app/values.yaml
+++ b/helm/kube-state-metrics-app/values.yaml
@@ -12,6 +12,7 @@ replicas: 1
 image:
   registry: quay.io
   name: giantswarm/kube-state-metrics
+  # when updating tag make sure to also keep appVersion in Chart.yaml in sync
   tag: v1.9.2
 
 imageResizer:


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/8529

Upstream kube-state-metrics v1.9.2 includes some segfault / NPE fixes (see https://github.com/kubernetes/kube-state-metrics/releases/tag/v1.9.2)
Upstream addon-resizer 1.8.7 release switched to apps/v1 Deployment API making it compatible with k8s 1.16 (see commits for 1.8 branch https://github.com/kubernetes/autoscaler/commits/addon-resizer-release-1.8/addon-resizer)

This PR upgrades both of these dependencies.