### PR TITLE
Change RBAC apiGroup from extensions to apps

### DIFF
--- a/helm/kube-state-metrics-app/templates/rbac.yaml
+++ b/helm/kube-state-metrics-app/templates/rbac.yaml
@@ -142,7 +142,7 @@ rules:
   resources:
   - pods
   verbs: ["get"]
-- apiGroups: ["extensions"]
+- apiGroups: ["apps"]
   resources:
   - deployments
   resourceNames: ["{{ .Values.name }}"]


### PR DESCRIPTION
Fixes the following RBAC issue by adjusting the apiGroup from the deprecated `extensions`:
```
kubectl logs -n kube-system   kube-state-metrics-59bcb7f65-48srx addon-resizer
ERROR: logging before flag.Parse: E0122 00:24:16.476375       1 nanny_lib.go:110] 
deployments.apps "kube-state-metrics" is forbidden: User "system:serviceaccount:kube-
system:kube-state-metrics" cannot get resource "deployments" in API group "apps" in 
the namespace "kube-system"
```