### PR TITLE
Add get/update deployments permissions

### DIFF
--- a/helm/kube-state-metrics-app/templates/rbac.yaml
+++ b/helm/kube-state-metrics-app/templates/rbac.yaml
@@ -53,6 +53,8 @@ rules:
   verbs:
   - list
   - watch
+  - get
+  - update
 - apiGroups:
   - certificates.k8s.io
   resources:


### PR DESCRIPTION
Following on from https://github.com/giantswarm/kube-state-metrics-app/pull/16

This PR fixes the following two errors. I tested the ClusterRole change manually, but not this code change as an app. Guidance on whether we should use more fine grained permissions or stick with this approach would be appreciated.

`ERROR: logging before flag.Parse: E0122 12:55:44.345504       1 nanny_lib.go:110] deployments.apps "kube-state-metrics" is forbidden: User "system:serviceaccount:kube-system:kube-state-metrics" cannot get resource "deployments" in API group "apps" in the namespace "kube-system"`
`ERROR: logging before flag.Parse: E0122 12:56:24.371377       1 nanny_lib.go:110] deployments.apps "kube-state-metrics" is forbidden: User "system:serviceaccount:kube-system:kube-state-metrics" cannot update resource "deployments" in API group "apps" in the namespace "kube-system"`