### PR TITLE
Move 1.0.2 changelog to 1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,18 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project's packages adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [v1.0.2]
-
-### Changed
-
-- Adjust RBAC configuration for k8s 1.16 compatibility
-
 ## [v1.0.1]
 
 ### Changed
 
 - Upgrade to kube-state-metrics [1.9.2](https://github.com/kubernetes/kube-state-metrics/releases/tag/v1.9.2)
 - Upgrade to k8s 1.16 compatible addon-resizer release 1.8.7
+- Adjust RBAC configuration for k8s 1.16 compatibility
 
 ## [v1.0.0]
 


### PR DESCRIPTION
Continuing from https://github.com/giantswarm/default-catalog/pull/4, I am combining 1.0.2 into 1.0.1 for rerelease.