### PR TITLE
Add app selector back

### DIFF
--- a/helm/kube-state-metrics-app/templates/_helpers.tpl
+++ b/helm/kube-state-metrics-app/templates/_helpers.tpl
@@ -31,6 +31,7 @@ helm.sh/chart: {{ include "chart" . | quote }}
 Selector labels
 */}}
 {{- define "labels.selector" -}}
+app: {{ .Values.name | quote }}
 app.kubernetes.io/name: {{ include "name" . | quote }}
 app.kubernetes.io/instance: {{ .Release.Name | quote }}
 {{- end -}}

--- a/integration/test/basic/main_test.go
+++ b/integration/test/basic/main_test.go
@@ -151,6 +151,7 @@ func init() {
 							"helm.sh/chart":                chartID,
 						},
 						MatchLabels: map[string]string{
+							"app":                        app,
 							"app.kubernetes.io/name":     app,
 							"app.kubernetes.io/instance": appName,
 						},


### PR DESCRIPTION
This should allow us to upgrade `kube-state-metrics` again. Still need to test.