### PR TITLE
Fix RBAC permission for leases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix permission to list and watch `leases.coordination.k8s.io`.
+
 ## [1.5.0] - 2021-11-29
 
 ### Changed

--- a/helm/kube-state-metrics-app/templates/rbac.yaml
+++ b/helm/kube-state-metrics-app/templates/rbac.yaml
@@ -128,6 +128,13 @@ rules:
   verbs:
   - list
   - watch
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - list
+  - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 # kubernetes versions before 1.8.0 should use rbac.authorization.k8s.io/v1beta1


### PR DESCRIPTION
Fixes

```
E1130 14:04:35.159571       1 reflector.go:138] pkg/mod/k8s.io/client-go@v0.22.0/tools/cache/reflector.go:167: Failed to watch *v1.Lease: failed to list *v1.Lease: leases.coordination.k8s.io is forbidden: User "system:serviceaccount:kube-system:kube-state-metrics" cannot list resource "leases" in API group "coordination.k8s.io" in the namespace "kube-node-lease"
```