### PR TITLE
add metrics labels allowlist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed missing labels from kube_<resource-name>_labels
+
 ## [1.6.0] - 2022-01-04
 
 ### Changed

--- a/helm/kube-state-metrics-app/templates/deployment.yaml
+++ b/helm/kube-state-metrics-app/templates/deployment.yaml
@@ -27,7 +27,7 @@ spec:
         {{- end }}
         args:
         - '--port={{ .Values.port }}'
-        - '--metric-labels-allowlist=daemonsets=[giantswarm.io/monitoring_basic_sli],deployments[giantswarm.io/monitoring_basic_sli,giantswarm.io/service_type],nodes=[ip],statefulsets=[giantswarm.io/monitoring_basic_sli]'
+        - '--metric-labels-allowlist=daemonsets=[giantswarm.io/monitoring_basic_sli],deployments=[giantswarm.io/monitoring_basic_sli,giantswarm.io/service_type],nodes=[ip],statefulsets=[giantswarm.io/monitoring_basic_sli]'
         livenessProbe:
           httpGet:
             path: /healthz

--- a/helm/kube-state-metrics-app/templates/deployment.yaml
+++ b/helm/kube-state-metrics-app/templates/deployment.yaml
@@ -27,6 +27,7 @@ spec:
         {{- end }}
         args:
         - '--port={{ .Values.port }}'
+        - '--metric-labels-allowlist=daemonsets=[giantswarm.io/monitoring_basic_sli],deployments[giantswarm.io/monitoring_basic_sli,giantswarm.io/service_type],nodes=[ip],statefulsets=[giantswarm.io/monitoring_basic_sli]'
         livenessProbe:
           httpGet:
             path: /healthz


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/20510

Allow some metrics to be ported in `kube_<resource-name>_labels` this has changed in kube-state-metrics 2.x

  * daemonsets: giantswarm.io/monitoring_basic_sli

  * deployments: giantswarm.io/monitoring_basic_sli, giantswarm.io/service_type

  * nodes: ip

  * statefulsets: giantswarm.io/monitoring_basic_sli
