### PR TITLE
Raise priorityClass to `system-cluster-critical` to increase scheduling chances in master-only clusters.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Raise priorityClass to `system-cluster-critical` to increase scheduling chances in master-only clusters.
+
 ## [1.6.1] - 2022-02-04
 
 ### Fixed

--- a/helm/kube-state-metrics-app/templates/deployment.yaml
+++ b/helm/kube-state-metrics-app/templates/deployment.yaml
@@ -17,7 +17,7 @@ spec:
       labels:
         {{- include "labels.common" . | nindent 8 }}
     spec:
-      priorityClassName: giantswarm-critical
+      priorityClassName: system-cluster-critical
       containers:
       - name: {{ include "resource.default.name" . }}
         {{- if .Values.isManagementCluster }}


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/20888

