### PR TITLE
Allow giantswarm.io/service-type label to be exported from Deployment…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Allow `giantswarm.io/service-type` labels from kube_<resource-name>_labels (Deployment, DaemonSet, StatefulSet)
+
 ## [1.7.0] - 2022-02-16
 
 ### Changed

--- a/helm/kube-state-metrics-app/templates/deployment.yaml
+++ b/helm/kube-state-metrics-app/templates/deployment.yaml
@@ -27,7 +27,7 @@ spec:
         {{- end }}
         args:
         - '--port={{ .Values.port }}'
-        - '--metric-labels-allowlist=daemonsets=[giantswarm.io/monitoring_basic_sli],deployments=[giantswarm.io/monitoring_basic_sli,giantswarm.io/service_type],nodes=[ip],statefulsets=[giantswarm.io/monitoring_basic_sli]'
+        - '--metric-labels-allowlist=daemonsets=[giantswarm.io/monitoring_basic_sli,giantswarm.io/service-type],deployments=[giantswarm.io/monitoring_basic_sli,giantswarm.io/service-type],nodes=[ip],statefulsets=[giantswarm.io/monitoring_basic_sli,giantswarm.io/service-type]'
         livenessProbe:
           httpGet:
             path: /healthz


### PR DESCRIPTION
…s, DaemonSets and StatefulSets

This PR fixes missing labels

Towards https://github.com/giantswarm/giantswarm/issues/21615