### PR TITLE
Make metric-labels-allowlist configurable from values.yaml 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Make `--metric-labels-allowlist` configurable through user values.
+
 ## [1.8.0] - 2022-04-06
 
 ### Changed

--- a/helm/kube-state-metrics-app/templates/_helpers.tpl
+++ b/helm/kube-state-metrics-app/templates/_helpers.tpl
@@ -34,3 +34,13 @@ Selector labels
 app.kubernetes.io/name: {{ include "name" . | quote }}
 app.kubernetes.io/instance: {{ .Release.Name | quote }}
 {{- end -}}
+
+{{/*
+Metric labels allowlist helper
+*/}}
+{{- define "kube-state-metrics.metric-labels-allowlist" -}}
+{{- range $i, $resource := sortAlpha (keys .Values.metricLabelsAllowlist) -}}
+{{- if $i -}},{{- end -}}
+{{ $resource }}=[{{- range $j, $label := sortAlpha (get $.Values.metricLabelsAllowlist $resource) -}}{{- if $j -}},{{- end -}}{{- $label -}}{{- end -}}]
+{{- end -}}
+{{- end -}}

--- a/helm/kube-state-metrics-app/templates/deployment.yaml
+++ b/helm/kube-state-metrics-app/templates/deployment.yaml
@@ -27,7 +27,7 @@ spec:
         {{- end }}
         args:
         - '--port={{ .Values.port }}'
-        - '--metric-labels-allowlist=daemonsets=[giantswarm.io/monitoring_basic_sli,giantswarm.io/service-type],deployments=[giantswarm.io/monitoring_basic_sli,giantswarm.io/service-type],nodes=[ip],statefulsets=[giantswarm.io/monitoring_basic_sli,giantswarm.io/service-type]'
+        - '--metric-labels-allowlist={{- include "kube-state-metrics.metric-labels-allowlist" . }}'
         livenessProbe:
           httpGet:
             path: /healthz

--- a/helm/kube-state-metrics-app/values.yaml
+++ b/helm/kube-state-metrics-app/values.yaml
@@ -29,3 +29,19 @@ test:
 
 registry:
   domain: docker.io
+
+metricLabelsAllowlist:
+  daemonsets:
+  - giantswarm.io/monitoring_basic_sli
+  - giantswarm.io/service-type
+  - app.kubernetes.io/name
+  deployments:
+  - giantswarm.io/monitoring_basic_sli
+  - giantswarm.io/service-type
+  - app.kubernetes.io/name
+  nodes:
+  - ip
+  statefulsets:
+  - giantswarm.io/monitoring_basic_sli
+  - giantswarm.io/service-type
+  - app.kubernetes.io/name


### PR DESCRIPTION
and add allow `app.kubernetes.io/name`.

I'm planning to release this as `1.9.0`