### PR TITLE
Node pool labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,6 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 ### Changed
 
 - Add `Node Pool` labels to the default allowed labels in `--metric-labels-allowlist`.
-- Add `kubernetes.io/role` label to the default allowed labels in `--metric-labels-allowlist`.
 
 ## [1.9.0] - 2022-04-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Add `Node Pool` labels to the default allowed labels in `--metric-labels-allowlist`.
+
 ## [1.9.0] - 2022-04-06
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 ### Changed
 
 - Add `Node Pool` labels to the default allowed labels in `--metric-labels-allowlist`.
+- Add `kubernetes.io/role` label to the default allowed labels in `--metric-labels-allowlist`.
 
 ## [1.9.0] - 2022-04-06
 

--- a/helm/kube-state-metrics-app/values.yaml
+++ b/helm/kube-state-metrics-app/values.yaml
@@ -41,6 +41,8 @@ metricLabelsAllowlist:
   - app.kubernetes.io/name
   nodes:
   - ip
+  - giantswarm.io/machine-pool
+  - giantswarm.io/machine-deployment
   statefulsets:
   - giantswarm.io/monitoring_basic_sli
   - giantswarm.io/service-type

--- a/helm/kube-state-metrics-app/values.yaml
+++ b/helm/kube-state-metrics-app/values.yaml
@@ -43,6 +43,7 @@ metricLabelsAllowlist:
   - ip
   - giantswarm.io/machine-pool
   - giantswarm.io/machine-deployment
+  - kubernetes.io/role
   statefulsets:
   - giantswarm.io/monitoring_basic_sli
   - giantswarm.io/service-type

--- a/helm/kube-state-metrics-app/values.yaml
+++ b/helm/kube-state-metrics-app/values.yaml
@@ -43,7 +43,6 @@ metricLabelsAllowlist:
   - ip
   - giantswarm.io/machine-pool
   - giantswarm.io/machine-deployment
-  - kubernetes.io/role
   statefulsets:
   - giantswarm.io/monitoring_basic_sli
   - giantswarm.io/service-type


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/21428

We want to know which node pool a node belongs to. This PR allows the node labels containing the node pool name to be exposed as a prometheus label.