### PR TITLE
values: Allow region & zone labels.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Add
+
+- Allow `topology.kubernetes.io/region` & `topology.kubernetes.io/zone` labels.
+
 ## [1.12.1] - 2022-08-29
 
 ### Changed 

--- a/helm/kube-state-metrics/values.yaml
+++ b/helm/kube-state-metrics/values.yaml
@@ -171,7 +171,7 @@ metricLabelsAllowlist:
 # - namespaces=[k8s-label-1,k8s-label-n]
   - daemonsets=[giantswarm.io/monitoring_basic_sli, giantswarm.io/service-type, app.kubernetes.io/name, application.giantswarm.io/team]
   - deployments=[giantswarm.io/monitoring_basic_sli, giantswarm.io/service-type, app.kubernetes.io/name, application.giantswarm.io/team]
-  - nodes=[ip, giantswarm.io/machine-pool, giantswarm.io/machine-deployment]
+  - nodes=[ip, giantswarm.io/machine-pool, giantswarm.io/machine-deployment, topology.kubernetes.io/region, topology.kubernetes.io/zone]
   - statefulsets=[giantswarm.io/monitoring_basic_sli, giantswarm.io/service-type, app.kubernetes.io/name, application.giantswarm.io/team]
 
 # Comma-separated list of Kubernetes annotations keys that will be used in the resource'


### PR DESCRIPTION
Add `topology.kubernetes.io/region` & `topology.kubernetes.io/zone` to `metric-labels-allowlist`.

Towards https://github.com/giantswarm/giantswarm/issues/21426.