### PR TITLE
Set helm chart ownership to team atlas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Set Helm chart ownership to team atlas.
+
 ## [1.14.0] - 2022-09-15
 
 ### Changed

--- a/helm/kube-state-metrics/Chart.yaml
+++ b/helm/kube-state-metrics/Chart.yaml
@@ -22,3 +22,4 @@ maintainers:
   email: davidcalvertfr@gmail.com
 annotations:
   config.giantswarm.io/version: 1.x.x
+  application.giantswarm.io/team: "atlas"

--- a/helm/kube-state-metrics/templates/_helpers.tpl
+++ b/helm/kube-state-metrics/templates/_helpers.tpl
@@ -72,6 +72,7 @@ app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 release: {{ .Release.Name }}
 {{- end }}
 "giantswarm.io/service-type": "managed"
+application.giantswarm.io/team: {{ index .Chart.Annotations "application.giantswarm.io/team" | quote }}
 {{- end }}
 
 {{/*


### PR DESCRIPTION
The missing annotation makes this alert to fire

![image](https://user-images.githubusercontent.com/627038/203263978-e62923ae-374c-4dfb-b04a-cace41d3c1bb.png)


According to [the ownership spreadsheet](https://docs.google.com/spreadsheets/d/1GNXAbYo_HyjjRusd2KTGttuORBkX9iMdgnNp-xTQ9sw/edit#gid=0) this app belongs to team atlas.