### PR TITLE
Add cilium network policies support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Added
+
+- Add cilium network policies.
+
 ## [1.14.2] - 2023-01-10
 
 ### Changed

--- a/helm/kube-state-metrics/templates/ciliumnetworkpolicy.yaml
+++ b/helm/kube-state-metrics/templates/ciliumnetworkpolicy.yaml
@@ -1,0 +1,16 @@
+{{ if .Values.ciliumNetworkPolicy.enabled }}
+apiVersion: "cilium.io/v2"
+kind: CiliumNetworkPolicy
+metadata:
+  name: {{ template "kube-state-metrics.fullname" . }}
+  namespace: {{ template "kube-state-metrics.namespace" . }}
+  labels:
+    {{- include "kube-state-metrics.labels" . | indent 4 }}
+spec:
+  endpointSelector:
+    matchLabels:
+      {{- include "kube-state-metrics.selectorLabels" . | indent 6 }}
+  egress:
+    - toEntities:
+        - kube-apiserver
+{{ end }}

--- a/helm/kube-state-metrics/values.yaml
+++ b/helm/kube-state-metrics/values.yaml
@@ -272,3 +272,6 @@ volumes: []
 #  - configMap:
 #      name: cm-for-volume
 #    name: config-volume
+
+ciliumNetworkPolicy:
+  enabled: false


### PR DESCRIPTION
When switching to cilium, we lost support for defining network policies that define CIDRs as targets, such as the one we use in this app to allow egress to the API server.
This PR adds a ciliumnetworkpolicy (disabled by default, enabled by `cluster-operator` in vintage clusters) to overcome this cilium limitation.

See https://github.com/giantswarm/giantswarm/issues/23014#issuecomment-1476207008