### PR TITLE
Deprecate chart

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,31 +50,3 @@ workflows:
           filters:
             tags:
               only: /^v.*/
-
-      - architect/push-to-app-collection:
-          context: architect
-          name: push-to-aws-app-collection
-          app_name: "kube-state-metrics"
-          app_namespace: "monitoring"
-          app_collection_repo: "aws-app-collection"
-          requires:
-            - push-to-control-plane-app-catalog
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /^v.*/
-
-      - architect/push-to-app-collection:
-          context: architect
-          name: push-to-azure-app-collection
-          app_name: "kube-state-metrics"
-          app_namespace: "monitoring"
-          app_collection_repo: "azure-app-collection"
-          requires:
-            - push-to-control-plane-app-catalog
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /^v.*/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Deprecate chart.
+
 ## [1.15.0] - 2023-04-04
 
 ### Added


### PR DESCRIPTION
This PR stops any push to collections so we can deprecate the chart in order to use KSM in the prometheus operator app as described here: https://github.com/giantswarm/giantswarm/issues/26221