### PR TITLE
feat: Align KSM config with kube-prometheus-stack-app and fix node label

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,6 +14,9 @@ workflows:
           ct_config: .abs/ct.yaml
           app_catalog: default-catalog
           app_catalog_test: default-test-catalog
+          # Keep appVersion pinned to the bundled KSM binary version (Chart.yaml),
+          # do not overwrite it with the chart git tag.
+          override_app_version: false
           filters:
             branches:
               ignore:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,5 +10,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add icon to chart.yaml
+- Enable `selfMonitor` to scrape the kube-state-metrics telemetry endpoint, aligning with `kube-prometheus-stack-app`.
+
+### Changed
+
+- Align KSM config with `kube-prometheus-stack-app`: raise CPU limit to `2000m` (so VPA can scale up), add `app.circleci.com/circle-project-reponame` to the pods metric label allowlist, and disable `podSecurityPolicy`.
+
+### Fixed
+
+- Fix invalid `node]` target label in the ServiceMonitor relabeling config.
+- Set `override_app_version: false` in CI so the chart `appVersion` stays pinned to the bundled kube-state-metrics binary version instead of the chart git tag.
 
 [Unreleased]: https://github.com/giantswarm/kube-state-metrics/tree/main

--- a/helm/kube-state-metrics/Chart.yaml
+++ b/helm/kube-state-metrics/Chart.yaml
@@ -10,6 +10,6 @@ dependencies:
   - name: kube-state-metrics
     version: 7.5.1
     repository: https://prometheus-community.github.io/helm-charts
-version: 0.1.0
+version: 0.2.0
 annotations:
   application.giantswarm.io/team: tenet

--- a/helm/kube-state-metrics/Chart.yaml
+++ b/helm/kube-state-metrics/Chart.yaml
@@ -10,6 +10,6 @@ dependencies:
   - name: kube-state-metrics
     version: 7.5.1
     repository: https://prometheus-community.github.io/helm-charts
-version: 0.2.0
+version: 0.1.0
 annotations:
   application.giantswarm.io/team: tenet

--- a/helm/kube-state-metrics/values.yaml
+++ b/helm/kube-state-metrics/values.yaml
@@ -89,13 +89,13 @@ kube-state-metrics:
           replacement: kube-state-metrics
         # Add node label.
         - sourceLabels: [__meta_kubernetes_pod_node_name]
-          targetLabel: node]
+          targetLabel: node
 
   ## Specify if a Pod Security Policy for kube-state-metrics must be created
   ## Ref: https://kubernetes.io/docs/concepts/policy/pod-security-policy/
   ##
   podSecurityPolicy:
-    enabled: true
+    enabled: false
 
   ## Configure network policy for kube-state-metrics
   networkPolicy:
@@ -169,7 +169,7 @@ kube-state-metrics:
     - daemonsets=[application.giantswarm.io/team, app.kubernetes.io/name, app.kubernetes.io/component, app.kubernetes.io/instance, app.kubernetes.io/version, giantswarm.io/service-type, helm.toolkit.fluxcd.io/name, helm.toolkit.fluxcd.io/namespace]
     - deployments=[application.giantswarm.io/team, app.kubernetes.io/name, app.kubernetes.io/component, app.kubernetes.io/instance, app.kubernetes.io/version, giantswarm.io/service-type, helm.toolkit.fluxcd.io/name, helm.toolkit.fluxcd.io/namespace]
     - nodes=[giantswarm.io/machine-pool, giantswarm.io/machine-deployment, ip, node.kubernetes.io/instance-type, topology.kubernetes.io/region, topology.kubernetes.io/zone]
-    - pods=[application.giantswarm.io/team, app.kubernetes.io/name, app.kubernetes.io/component, app.kubernetes.io/instance, giantswarm.io/service-type]
+    - pods=[app.circleci.com/circle-project-reponame, application.giantswarm.io/team, app.kubernetes.io/name, app.kubernetes.io/component, app.kubernetes.io/instance, giantswarm.io/service-type]
     - statefulsets=[application.giantswarm.io/team, app.kubernetes.io/name, app.kubernetes.io/component, app.kubernetes.io/instance, app.kubernetes.io/version, giantswarm.io/service-type, helm.toolkit.fluxcd.io/name, helm.toolkit.fluxcd.io/namespace]
 
   # Available collectors for kube-state-metrics.
@@ -208,13 +208,18 @@ kube-state-metrics:
     # - clusterroles
     # - roles
 
+  ## We set resources so VPA can do its thing
   resources:
     limits:
-      cpu: 200m
+      cpu: 2000m
       memory: 200Mi
     requests:
       cpu: 200m
       memory: 200Mi
+
+  # Scrape the kube-state-metrics own /metrics (telemetry) endpoint
+  selfMonitor:
+    enabled: true
 
   # Enable vertical pod autoscaler support for kube-state-metrics
   verticalPodAutoscaler:


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/35294

Aligns the standalone kube-state-metrics chart with the KSM config currently shipped inside `kube-prometheus-stack-app`, as a first step towards extracting KSM into its own app.

- Fix invalid `node]` target label in the ServiceMonitor relabeling config.
- Raise CPU limit to `2000m` so VPA can scale up (with `minAllowed: 200m` a 200m limit blocked it).
- Add `app.circleci.com/circle-project-reponame` to the pods metric label allowlist.
- Disable `podSecurityPolicy` (removed in k8s 1.25+).
- Enable `selfMonitor` to scrape the kube-state-metrics telemetry endpoint.
- Set `override_app_version: false` in CI so `appVersion` stays pinned to the bundled KSM binary version instead of the chart git tag.